### PR TITLE
Fix missing links to dependencies of libtempered

### DIFF
--- a/libtempered/CMakeLists.txt
+++ b/libtempered/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 
 if (BUILD_SHARED_LIB)
 	add_library(tempered-shared SHARED ${libtempered_FILES})
+	target_link_libraries(tempered-shared ${HIDAPI_LINK_LIBS})
 	set_target_properties(tempered-shared PROPERTIES
 		OUTPUT_NAME tempered
 		SOVERSION 0
@@ -22,6 +23,7 @@ endif()
 
 if (BUILD_STATIC_LIB)
 	add_library(tempered-static STATIC ${libtempered_FILES})
+	target_link_libraries(tempered-static ${HIDAPI_LINK_LIBS})
 	set_target_properties(tempered-static PROPERTIES
 		OUTPUT_NAME tempered
 	)


### PR DESCRIPTION
Allows the library to be usable with python ctypes, as otherwise trying to do so fails with

```
OSError: lib/libtempered.so: undefined symbol: hid_error
```

I have a feeling that not actually being linked to it's dependencies might have caused other issues as well, though I'm not familiar enough with the details of shared library loading to say.
