### PR TITLE
Fixes libtempered error string handling

### DIFF
--- a/examples/enumerate.c
+++ b/examples/enumerate.c
@@ -8,19 +8,17 @@ This example shows how to enumerate the attached devices.
 
 int main( void )
 {
-	char *error = NULL;
-	if ( !tempered_init( &error ) )
+	char error[256];
+	if ( !tempered_init( error, sizeof(error) ) )
 	{
 		fprintf( stderr, "%s\n", error );
-		free( error );
 		return 1;
 	}
 	
-	struct tempered_device_list *list = tempered_enumerate( &error );
+	struct tempered_device_list *list = tempered_enumerate( error, sizeof(error) );
 	if ( list == NULL )
 	{
 		fprintf( stderr, "%s\n", error );
-		free( error );
 	}
 	else
 	{
@@ -39,10 +37,9 @@ int main( void )
 		tempered_free_device_list( list );
 	}
 	
-	if ( !tempered_exit( &error ) )
+	if ( !tempered_exit( error, sizeof(error) ) )
 	{
 		fprintf( stderr, "%s\n", error );
-		free( error );
 		return 1;
 	}
 	return 0;

--- a/examples/read-all.c
+++ b/examples/read-all.c
@@ -60,12 +60,11 @@ void read_device( struct tempered_device_list *dev )
 		dev->interface_number,
 		dev->type_name
 	);
-	char *error = NULL;
-	tempered_device *device = tempered_open( dev, &error );
+	char error[256];
+	tempered_device *device = tempered_open( dev, error, sizeof(error) );
 	if ( device == NULL )
 	{
 		printf( "\tOpen failed, error: %s\n", error );
-		free( error );
 		return;
 	}
 	printf(

--- a/examples/read-all.c
+++ b/examples/read-all.c
@@ -96,15 +96,14 @@ void read_device( struct tempered_device_list *dev )
 
 int main( void )
 {
-	char *error = NULL;
-	if ( !tempered_init( &error ) )
+	char error[256];
+	if ( !tempered_init( error, sizeof(error) ) )
 	{
 		fprintf( stderr, "Failed to initialize libtempered: %s\n", error );
-		free( error );
 		return 1;
 	}
 	
-	struct tempered_device_list *list = tempered_enumerate( &error );
+	struct tempered_device_list *list = tempered_enumerate( error, sizeof(error) );
 	if ( list == NULL )
 	{
 		if ( error == NULL )
@@ -114,7 +113,6 @@ int main( void )
 		else
 		{
 			fprintf( stderr, "Failed to enumerate devices: %s\n", error );
-			free( error );
 		}
 	}
 	else
@@ -127,10 +125,9 @@ int main( void )
 		tempered_free_device_list( list );
 	}
 	
-	if ( !tempered_exit( &error ) )
+	if ( !tempered_exit( error, sizeof(error) ) )
 	{
 		fprintf( stderr, "Failed to shut down libtempered: %s\n", error );
-		free( error );
 		return 1;
 	}
 	return 0;

--- a/examples/read-repeat.c
+++ b/examples/read-repeat.c
@@ -82,19 +82,11 @@ void read_repeatedly( tempered_device *device )
 /** Open the device with the given device path. */
 tempered_device* open_device( char *dev_path )
 {
-	char *error = NULL;
+	char error[256];
 	struct tempered_device_list *list = tempered_enumerate( error, sizeof(error) );
 	if ( list == NULL )
 	{
-		if ( error == NULL )
-		{
-			printf( "No devices were found.\n" );
-		}
-		else
-		{
-			fprintf( stderr, "Failed to enumerate devices: %s\n", error );
-			free( error );
-		}
+		fprintf( stderr, "Failed to enumerate devices: %s\n", error );
 		return NULL;
 	}
 	tempered_device *device = NULL;
@@ -105,7 +97,7 @@ tempered_device* open_device( char *dev_path )
 		if ( strcmp( dev->path, dev_path ) == 0 )
 		{
 			found = true;
-			device = tempered_open( dev, &error );
+			device = tempered_open( dev, error, sizeof(error) );
 			break;
 		}
 	}
@@ -118,7 +110,6 @@ tempered_device* open_device( char *dev_path )
 				stderr, "Opening %s failed, error: %s\n",
 				dev_path, error
 			);
-			free( error );
 		}
 		else
 		{

--- a/examples/read-repeat.c
+++ b/examples/read-repeat.c
@@ -55,11 +55,11 @@ void read_device_sensor( tempered_device *device, int sensor )
 void read_repeatedly( tempered_device *device )
 {
 	int i;
-	for ( i = 0; i < 10; i++ )
+	for ( i = 0; i < 500; i++ )
 	{
 		if ( i > 0 )
 		{
-			sleep( 5 );
+			sleep( 1 );
 		}
 		if ( !tempered_read_sensors( device ) )
 		{
@@ -83,7 +83,7 @@ void read_repeatedly( tempered_device *device )
 tempered_device* open_device( char *dev_path )
 {
 	char *error = NULL;
-	struct tempered_device_list *list = tempered_enumerate( &error );
+	struct tempered_device_list *list = tempered_enumerate( error, sizeof(error) );
 	if ( list == NULL )
 	{
 		if ( error == NULL )
@@ -135,11 +135,10 @@ int main( int argc, char *argv[] )
 		fprintf( stderr, "Usage: read-repeat <device>\n" );
 		return 1;
 	}
-	char *error = NULL;
-	if ( !tempered_init( &error ) )
+	char error[256];
+	if ( !tempered_init( error, sizeof(error) ) )
 	{
 		fprintf( stderr, "Failed to initialize libtempered: %s\n", error );
-		free( error );
 		return 1;
 	}
 	
@@ -150,10 +149,9 @@ int main( int argc, char *argv[] )
 		tempered_close( device );
 	}
 	
-	if ( !tempered_exit( &error ) )
+	if ( !tempered_exit( error, sizeof(error) ) )
 	{
 		fprintf( stderr, "Failed to shut down libtempered: %s\n", error );
-		free( error );
 		return 1;
 	}
 	return 0;

--- a/libtempered/core.c
+++ b/libtempered/core.c
@@ -23,21 +23,59 @@ void tempered_set_error( tempered_device *device, char *error )
 }
 
 /** Initialize the TEMPered library. */
-bool tempered_init( char **error )
+bool tempered_init( char *error, size_t err_size )
 {
-	return temper_type_init( error );
+	if ( error == NULL ) //don't need to handle error messages
+	{
+		return temper_type_init( NULL );
+	}
+
+	char *err;
+	if ( !temper_type_init( &err ) )
+	{
+		snprintf(error, err_size, "%s", err);
+		free(err); //free the damn thing
+
+		return false;
+	}
+	return true;
 }
 
 /** Finalize the TEMPered library. */
-bool tempered_exit( char **error )
+bool tempered_exit( char *error, size_t err_size )
 {
-	return temper_type_exit( error );
+	if ( error == NULL ) //don't need to handle error messages
+	{
+		return temper_type_init( NULL );
+	}
+
+	char *err;
+	if ( !temper_type_exit( &err ) )
+	{
+		snprintf(error, err_size, "%s", err);
+		free(err); //free the damn thing
+
+		return false;
+	}
+	return true;
 }
 
 /** Enumerate the TEMPer devices. */
-struct tempered_device_list* tempered_enumerate( char **error )
+struct tempered_device_list* tempered_enumerate( char *error, size_t err_size )
 {
-	return temper_type_enumerate( error );
+	if ( error == NULL ) //don't need to handle error messages
+	{
+		return temper_type_enumerate( NULL );
+	}
+
+	char *err;
+	struct tempered_device_list *list = temper_type_enumerate( &err );
+	if ( list == NULL )
+	{
+		snprintf(error, err_size, "%s", err);
+		free(err); //free the damn thing
+	}
+	return list;
 }
 
 /** Free the memory used by the given device list. */

--- a/libtempered/core.c
+++ b/libtempered/core.c
@@ -133,13 +133,13 @@ static bool tempered_open__find_subtype( tempered_device *device )
 }
 
 /** Open a given device from the list. */
-tempered_device* tempered_open( struct tempered_device_list *list, char **error )
+tempered_device* tempered_open( struct tempered_device_list *list, char *error, size_t err_size )
 {
 	if ( list == NULL )
 	{
 		if ( error != NULL )
 		{
-			*error = strdup( "Invalid device given." );
+			snprintf( error, err_size, "Invalid device given." );
 		}
 		return NULL;
 	}
@@ -150,7 +150,7 @@ tempered_device* tempered_open( struct tempered_device_list *list, char **error 
 	{
 		if ( error != NULL )
 		{
-			*error = strdup( "Invalid device given (type not found)." );
+			snprintf( error, err_size, "Invalid device given (type not found)." );
 		}
 		return NULL;
 	}
@@ -158,7 +158,7 @@ tempered_device* tempered_open( struct tempered_device_list *list, char **error 
 	{
 		if ( error != NULL )
 		{
-			*error = strdup( "Device type has no open method." );
+			snprintf( error, err_size, "Device type has no open method." );
 		}
 		return NULL;
 	}
@@ -167,7 +167,7 @@ tempered_device* tempered_open( struct tempered_device_list *list, char **error 
 	{
 		if ( error != NULL )
 		{
-			*error = strdup( "Could not allocate memory for the device." );
+			snprintf( error, err_size, "Could not allocate memory for the device." );
 		}
 		return NULL;
 	}
@@ -180,7 +180,7 @@ tempered_device* tempered_open( struct tempered_device_list *list, char **error 
 	{
 		if ( error != NULL )
 		{
-			*error = strdup( "Could not allocate memory for the path." );
+			snprintf( error, err_size, "Could not allocate memory for the path." );
 		}
 		free( device );
 		return NULL;
@@ -191,11 +191,13 @@ tempered_device* tempered_open( struct tempered_device_list *list, char **error 
 		{
 			if ( device->error != NULL )
 			{
-				*error = device->error;
+				snprintf( error, err_size, 
+					"Type-specific device open failed with error: %s", device->error
+				);
 			}
 			else
 			{
-				*error = strdup(
+				snprintf( error, err_size,
 					"Type-specific device open failed with no error message."
 				);
 			}
@@ -212,7 +214,8 @@ tempered_device* tempered_open( struct tempered_device_list *list, char **error 
 	{
 		if ( error != NULL )
 		{
-			*error = device->error;
+			snprintf( error, err_size, "%s", device->error );
+			free( device->error );
 			device->error = NULL;
 		}
 		tempered_close( device );
@@ -226,12 +229,15 @@ tempered_device* tempered_open( struct tempered_device_list *list, char **error 
 			{
 				if ( device->error != NULL )
 				{
-					*error = device->error;
+					snprintf( error, err_size, 
+						"Type-specific device open failed with error: %s", device->error
+					);
+					free( device->error );
 					device->error = NULL;
 				}
 				else
 				{
-					*error = strdup(
+					snprintf( error, err_size,
 						"Type-specific device open failed with no error message."
 					);
 				}

--- a/libtempered/tempered.h
+++ b/libtempered/tempered.h
@@ -118,14 +118,15 @@ void tempered_free_device_list( struct tempered_device_list *list );
  * The returned handle should be closed with tempered_close() when you are done
  * using the device.
  * @param list The device list entry that should be opened.
- * @param error If an error occurs and this is not NULL, it will be set to the
- * error message. The returned string is dynamically allocated, and should be
- * freed when you're done with it.
+ * @param error If an error occurs and this is not NULL, the error message will
+ * be written to the given buffer.
+ * @param err_size If the buffer is too small for the error message it will be
+ * truncated.
  * @return The opened device, or NULL on error.
  * @see tempered_close()
  * @see tempered_enumerate()
  */
-tempered_device* tempered_open( struct tempered_device_list *list, char **error );
+tempered_device* tempered_open( struct tempered_device_list *list, char *error, size_t err_size );
 
 /** Close an open device.
  *

--- a/libtempered/tempered.h
+++ b/libtempered/tempered.h
@@ -69,37 +69,40 @@ typedef struct tempered_device_ tempered_device;
  * necessary, as it will be called automatically when needed, but should be
  * called at the start of execution if there's a chance the library will be
  * used by multiple threads simultaneously.
- * @param error If an error occurs and this is not NULL, it will be set to the
- * error message. The returned string is dynamically allocated, and should be
- * freed when you're done with it.
+ * @param error If an error occurs and this is not NULL, the error message will
+ * be written to the given buffer.
+ * @param err_size If the buffer is too small for the error message it will be
+ * truncated.
  * @return true on success, false on error.
  */
-bool tempered_init( char **error );
+bool tempered_init( char *error, size_t err_size );
 
 /** Finalize the TEMPered library.
  *
  * This function should be called at the end of execution to avoid memory leaks.
- * @param error If an error occurs and this is not NULL, it will be set to the
- * error message. The returned string is dynamically allocated, and should be
- * freed when you're done with it.
+ * @param error If an error occurs and this is not NULL, the error message will
+ * be written to the given buffer.
+ * @param err_size If the buffer is too small for the error message it will be
+ * truncated.
  * @return true on success, false on error.
  */
-bool tempered_exit( char **error );
+bool tempered_exit( char *error, size_t err_size );
 
 /** Enumerate the TEMPer devices.
  *
  * This function returns a linked list of all the recognized TEMPer devices
  * attached to the system (excluding the ones that are ignored).
  *
- * @param error If an error occurs and this is not NULL, it will be set to the
- * error message. The returned string is dynamically allocated, and should be
- * freed when you're done with it.
+ * @param error If an error occurs and this is not NULL, the error message will
+ * be written to the given buffer.
+ * @param err_size If the buffer is too small for the error message it will be
+ * truncated.
  * @return A pointer to the first device in the enumerated list, or NULL on
  * error. This list should be freed with tempered_free_device_list when you
  * are done with it.
  * If no devices were found, NULL is returned and the error remains unset.
  */
-struct tempered_device_list* tempered_enumerate( char **error );
+struct tempered_device_list* tempered_enumerate( char *error, size_t err_size );
 
 /** Free the memory used by the given device list.
  *

--- a/utils/tempered.c
+++ b/utils/tempered.c
@@ -245,15 +245,14 @@ void print_device(
 		);
 		return;
 	}
-	char *error = NULL;
-	tempered_device *device = tempered_open( dev, &error );
+	char error[256];
+	tempered_device *device = tempered_open( dev, error, sizeof(error) );
 	if ( device == NULL )
 	{
 		fprintf(
 			stderr, "%s: Could not open device: %s\n",
 			dev->path, error
 		);
-		free( error );
 		return;
 	}
 	if ( !tempered_read_sensors( device ) )

--- a/utils/tempered.c
+++ b/utils/tempered.c
@@ -282,20 +282,18 @@ int main( int argc, char *argv[] )
 	{
 		return 1;
 	}
-	char *error = NULL;
-	if ( !tempered_init( &error ) )
+	char error[256];
+	if ( !tempered_init( error, sizeof(error) ) )
 	{
 		fprintf( stderr, "Failed to initialize libtempered: %s\n", error );
-		free( error );
 		free_options( options );
 		return 1;
 	}
 	
-	struct tempered_device_list *list = tempered_enumerate( &error );
+	struct tempered_device_list *list = tempered_enumerate( error, sizeof(error) );
 	if ( list == NULL )
 	{
 		fprintf( stderr, "Failed to enumerate devices: %s\n", error );
-		free( error );
 	}
 	else
 	{
@@ -337,10 +335,9 @@ int main( int argc, char *argv[] )
 		tempered_free_device_list( list );
 	}
 	
-	if ( !tempered_exit( &error ) )
+	if ( !tempered_exit( error, sizeof(error) ) )
 	{
 		fprintf( stderr, "%s\n", error );
-		free( error );
 		free_options( options );
 		return 1;
 	}


### PR DESCRIPTION
A library should NEVER ask an application to free dynamically allocated memory. Unless the library is statically linked to the application, there is no guarantee that a free() in the application will line up with a malloc() in the library.

See [this discussion](http://www.gossamer-threads.com/lists/python/python/1019748), for example.

This PR removes the dynamically allocated error message strings and instead writes the messages to a caller specified buffer.
