### PR TITLE
Fixes tempered.h includes

### DIFF
--- a/libtempered/tempered.h
+++ b/libtempered/tempered.h
@@ -5,6 +5,7 @@
 extern "C" {
 #endif
 
+#include <stdlib.h>
 #include <stdbool.h>
 
 /** This file contains the headers that comprise the public API of the TEMPered


### PR DESCRIPTION
The header uses `size_t` but doesn't include it's definition. This allows the header to actually be used in other projects.
