### PR TITLE
Fix missing links to dependencies of libtempered

### DIFF
--- a/libtempered/CMakeLists.txt
+++ b/libtempered/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 
 if (BUILD_SHARED_LIB)
 	add_library(tempered-shared SHARED ${libtempered_FILES})
+	target_link_libraries(tempered-shared ${HIDAPI_LINK_LIBS})
 	set_target_properties(tempered-shared PROPERTIES
 		OUTPUT_NAME tempered
 		SOVERSION 0
@@ -22,6 +23,7 @@ endif()
 
 if (BUILD_STATIC_LIB)
 	add_library(tempered-static STATIC ${libtempered_FILES})
+	target_link_libraries(tempered-static ${HIDAPI_LINK_LIBS})
 	set_target_properties(tempered-static PROPERTIES
 		OUTPUT_NAME tempered
 	)


### PR DESCRIPTION
Makes the linker actually link the generated libtempered.so to libhidapi.so.

This allows the library to be usable with python ctypes (among other things, probably), as otherwise trying to do so fails with

```
OSError: lib/libtempered.so: undefined symbol: hid_error
```

This wasn't a problem when using the library in the same project but is probably necessary for using libtempered.so with other projects.
